### PR TITLE
Fix travis coverage reporting & only publish master to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: node_js
 node_js: node
 
 script:
-  - npm run test:ci
+  - npm run test
   - npm run build
+
+after_success:
+  - codecov
 
 deploy:
   provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ deploy:
   provider: npm
   email: joshfraser91@gmail.com
   api_key: $NPM_API_KEY
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "scripts": {
     "build": "rimraf dist/* && microbundle && rimraf dist/*mjs* dist/*umd* dist/*test*",
     "dev": "microbundle watch",
-    "coverage": "codecov",
-    "test": "jest",
-    "test:ci": "npm run test && npm run coverage"
+    "test": "jest"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Re-structures travis config to call `codecov` after success, and publish to npm for master branch only.