### PR TITLE
Add return value capability & make Travis only upload coverage report on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - npm run build
 
 after_success:
-  - codecov
+  - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && codecov
 
 deploy:
   provider: npm

--- a/README.md
+++ b/README.md
@@ -58,9 +58,65 @@ https://www.npmjs.com/package/eslint-plugin-react-hooks#advanced-configuration
 }
 ```
 
+## Advanced Usage
+
+The callback you provide to the hook typically will return a 'cleanup' function like so:
+
+```ts
+const greetAndAlert = useCallback((foo) => {
+  const calculatedResult = 'hello ' + foo;
+  const timeoutId = setTimeout(() => {
+    alert(calculatedResult);
+  }, 1000)
+  ...
+  return () => {
+    clearTimeout(timeoutId);
+  }
+}, []);
+```
+
+This means that when you later call the function, you don't get a meaningful return value to use for yourself.
+
+```ts
+const result = greetAndAlert("world");
+// `result` will just be the cleanup callback here!
+```
+
+While not anticipated to be a common use case, in order to both return a value _and_ use a cleanup callback, you can use object notation for the return value in the following shape:
+
+```ts
+{
+  value: unknown;
+  cleanup: () => void
+}
+```
+
+For example:
+
+```ts
+const greetAndAlert = useCallback((foo) => {
+  const calculatedResult = 'hello' + foo;
+  const timeoutId = setTimeout(() => {
+    alert(calculatedResult);
+  }, 1000)
+  ...
+  return {
+    value: calculatedResult,
+    cleanup: () => {
+      clearTimeout(timeoutId);
+    }
+  }
+})
+```
+
+```ts
+const result = greetAndAlert("world");
+// result === 'hello world'
+// `result` is returned here, *and* we still get to use the cleanup!
+```
+
 ## Limitations
 
-- As the provided callback expects a `cleanup callback` for the return value, it is not feasible to return a value when calling the memoized callback.
 - Similarly to `useEffect`, the `callback` and returned `cleanup callback` must be synchronous (i.e. an `async` function callback will not work). You can alleviate this the same way you would with `useEffect` by defining the asynchronous function within the callback, and calling it immediately.
 
   ```tsx

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A react hook that utilizes the 'cleanup callback' pattern of useEffect within a 
 
 - Provides a memoized callback that will update only if a `dependency` in the provided `dependency array` changes (same as `useCallback`).
 - Supports a `cleanup callback` within the provided callback which will be executed on the next successive function call, and/or on unmount.
+- Full Typescript support
 
 The features can be thought of as either `"useEffect which is called manually"`, or `"useCallback with useEffect's cleanup pattern"`.
 
@@ -60,15 +61,17 @@ https://www.npmjs.com/package/eslint-plugin-react-hooks#advanced-configuration
 
 ## Advanced Usage
 
-The callback you provide to the hook typically will return a 'cleanup' function like so:
+The callback you provide to the hook typically will return a 'cleanup' callback like so:
 
 ```ts
-const greetAndAlert = useCallback((foo) => {
+const greetAndAlert = useCleanupCallback((foo) => {
   const calculatedResult = 'hello ' + foo;
   const timeoutId = setTimeout(() => {
     alert(calculatedResult);
   }, 1000)
   ...
+
+  // cleanup callback:
   return () => {
     clearTimeout(timeoutId);
   }
@@ -94,12 +97,14 @@ While not anticipated to be a common use case, in order to both return a value _
 For example:
 
 ```ts
-const greetAndAlert = useCallback((foo) => {
+const greetAndAlert = useCleanupCallback((foo) => {
   const calculatedResult = 'hello' + foo;
   const timeoutId = setTimeout(() => {
     alert(calculatedResult);
   }, 1000)
   ...
+
+  // object notation return:
   return {
     value: calculatedResult,
     cleanup: () => {

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For example:
 
 ```ts
 const greetAndAlert = useCleanupCallback((foo) => {
-  const calculatedResult = 'hello' + foo;
+  const calculatedResult = 'hello ' + foo;
   const timeoutId = setTimeout(() => {
     alert(calculatedResult);
   }, 1000)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-cleanup-callback",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "React hook that is a hybrid of useCallback and the cleanup from useEffect",
   "main": "dist/index.js",
   "source": "src/index.ts",
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "rimraf dist/* && microbundle && rimraf dist/*mjs* dist/*umd* dist/*test*",
     "dev": "microbundle watch",
-    "test": "jest"
+    "test": "jest",
+    "test-watch": "jest --watch"
   },
   "keywords": [
     "react",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -169,4 +169,24 @@ describe("Expected behaviour", () => {
     expect(mockCallback).toBeCalledTimes(4);
     expect(mockCallback).toBeCalledWith("foo", "bar");
   });
+
+  test("Can return a value and cleanup in the callback when using object notation", () => {
+    const mockCleanup = jest.fn();
+
+    const inputCallback = () => {
+      return {
+        value: "foo",
+        cleanup: mockCleanup,
+      };
+    };
+
+    const { result } = renderHook(() => useCallbackCleanup(inputCallback, []));
+
+    expect(mockCleanup).not.toHaveBeenCalled;
+
+    const returnValue = result.current();
+
+    expect(returnValue).toBe("foo");
+    expect(mockCleanup).toHaveBeenCalled;
+  });
 });


### PR DESCRIPTION
Adds the option for the returned function to return a value, while still using the 'cleanup callback' functionality.  

Rather than returning just the cleanup callback:  
```ts
const func = useCleanupCallback() => {
  return () => {
    // clean up effect in here
  }
}, []);

func();
```
You can now return an object with keys 'value' and 'cleanup':  
```ts
const func = useCleanupCallback(() => {

  return {
    value: 'some return value',
    cleanup: () => {
      // clean up effect in here
    }
  }
}, []);

const result = func();
// result === 'some return value'
```  
Such that when calling the created function, it will return 'some return value' in the snippet above.

This is an optional usage, and is backwards compatible. More in depth examples are in the updated readme.  

This merge request also alters the `travis` config to only upload coverage for the `master` branch.